### PR TITLE
Splits aws-cli in own images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,19 @@ jobs:
     - stage: build 
       script: ./bin/docker_build_and_push.sh 11/jre/slim openjdk:11-jre openjdk:11-jre-slim
     - stage: build
+      script: ./bin/docker_build_and_push.sh 11/jre/slim-aws openjdk:11-jre-aws openjdk:11-jre-slim-aws
+    - stage: build
       script: ./bin/docker_build_and_push.sh 11/jdk/slim openjdk openjdk:11 openjdk:11-jdk openjdk:11-jdk-slim
+    - stage: build
+      script: ./bin/docker_build_and_push.sh 11/jdk/slim-aws openjdk:11-aws openjdk:11-jdk-aws openjdk:11-jdk-slim-aws
     - stage: build
       script: ./bin/docker_build_and_push.sh 10/jre/slim openjdk:10-jre openjdk:10-jre-slim
     - stage: build
+      script: ./bin/docker_build_and_push.sh 10/jre/slim-aws openjdk:10-jre-aws openjdk:10-jre-slim-aws
+    - stage: build
       script: ./bin/docker_build_and_push.sh 10/jdk/slim openjdk:10 openjdk:10-jdk openjdk:10-jdk-slim
+    - stage: build
+      script: ./bin/docker_build_and_push.sh 10/jdk/slim-aws openjdk:10-aws openjdk:10-jdk-aws openjdk:10-jdk-slim-aws
     - stage: build
       script: ./bin/docker_build_and_push.sh 8/jre/alpine openjdk:8 openjdk:8-jre openjdk:8-jre-alpine
 

--- a/10/jdk/slim-aws/Dockerfile
+++ b/10/jdk/slim-aws/Dockerfile
@@ -1,8 +1,10 @@
-FROM openjdk:11.0.1-jdk-slim
+FROM openjdk:10.0.2-13-jdk-slim
 MAINTAINER Forest Keepers
 
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
+
+ENV AWSCLI_VERSION 1.16.47
 
 RUN apt-get update && \
     apt-get install -y \
@@ -11,9 +13,15 @@ RUN apt-get update && \
       git \
       wget \
       curl \
+      python \
+      python-pip \
       bash && \
+    pip install --no-cache-dir awscli==$AWSCLI_VERSION && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean 
+
+RUN echo 'source $HOME/aws/env/bin/activate' >> .bashrc && \
+    echo 'complete -C aws_completer aws' >> .bashrc
 
 ADD REPO .
 

--- a/10/jdk/slim-aws/Dockerfile
+++ b/10/jdk/slim-aws/Dockerfile
@@ -1,5 +1,5 @@
 FROM openjdk:10.0.2-13-jdk-slim
-MAINTAINER Forest Keepers
+MAINTAINER Forest Keepers <Jeroen.knoops@philips.com>
 
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
@@ -8,8 +8,6 @@ ENV AWSCLI_VERSION 1.16.47
 
 RUN apt-get update && \
     apt-get install -y \
-      bzip2 \
-      unzip \
       git \
       wget \
       curl \
@@ -20,8 +18,15 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean 
 
-RUN echo 'source $HOME/aws/env/bin/activate' >> .bashrc && \
-    echo 'complete -C aws_completer aws' >> .bashrc
+RUN addgroup --system java && \
+    adduser --system --group java
+
+RUN mkdir /app
+RUN chown java:java /app
+
+USER java
+
+WORKDIR /app
 
 ADD REPO .
 

--- a/10/jdk/slim/Dockerfile
+++ b/10/jdk/slim/Dockerfile
@@ -13,16 +13,9 @@ RUN apt-get update && \
       git \
       wget \
       curl \
-      python \
-      python-pip \
       bash && \
-    pip install --no-cache-dir awscli==$AWSCLI_VERSION && \
-#    apt-get --purge autoremove python-pip -y && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean 
-
-RUN echo 'source $HOME/aws/env/bin/activate' >> .bashrc && \
-    echo 'complete -C aws_completer aws' >> .bashrc
 
 ADD REPO .
 

--- a/10/jdk/slim/Dockerfile
+++ b/10/jdk/slim/Dockerfile
@@ -1,21 +1,27 @@
 FROM openjdk:10.0.2-13-jdk-slim
-MAINTAINER Forest Keepers
+MAINTAINER Forest Keepers <Jeroen.knoops@philips.com>
 
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 
-ENV AWSCLI_VERSION 1.16.47
-
 RUN apt-get update && \
     apt-get install -y \
-      bzip2 \
-      unzip \
       git \
       wget \
       curl \
       bash && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean 
+
+RUN addgroup --system java && \
+    adduser --system --group java
+
+RUN mkdir /app
+RUN chown java:java /app
+
+USER java
+
+WORKDIR /app
 
 ADD REPO .
 

--- a/10/jre/slim-aws/Dockerfile
+++ b/10/jre/slim-aws/Dockerfile
@@ -1,5 +1,5 @@
 FROM openjdk:10.0.2-13-slim
-MAINTAINER Forest Keepers
+MAINTAINER Forest Keepers <Jeroen.knoops@philips.com>
 
 RUN apt-get update && \
     apt-get install -y \
@@ -14,9 +14,6 @@ RUN apt-get update && \
 ENV AWSCLI_VERSION 1.16.47
 
 RUN pip install awscli==$AWSCLI_VERSION
-
-RUN echo 'source $HOME/aws/env/bin/activate' >> .bashrc && \
-    echo 'complete -C aws_completer aws' >> .bashrc
 
 RUN addgroup --system java && \
     adduser --system --group java

--- a/10/jre/slim-aws/Dockerfile
+++ b/10/jre/slim-aws/Dockerfile
@@ -7,8 +7,16 @@ RUN apt-get update && \
       jq \
       openssl \
       net-tools \
+      python-pip \
       wget && \
     rm -rf /var/lib/apt/lists/*
+
+ENV AWSCLI_VERSION 1.16.47
+
+RUN pip install awscli==$AWSCLI_VERSION
+
+RUN echo 'source $HOME/aws/env/bin/activate' >> .bashrc && \
+    echo 'complete -C aws_completer aws' >> .bashrc
 
 RUN addgroup --system java && \
     adduser --system --group java

--- a/10/jre/slim/Dockerfile
+++ b/10/jre/slim/Dockerfile
@@ -1,5 +1,5 @@
 FROM openjdk:10.0.2-13-slim
-MAINTAINER Forest Keepers
+MAINTAINER Forest Keepers <Jeroen.knoops@philips.com>
 
 RUN apt-get update && \
     apt-get install -y \

--- a/11/jdk/slim-aws/Dockerfile
+++ b/11/jdk/slim-aws/Dockerfile
@@ -4,6 +4,8 @@ MAINTAINER Forest Keepers
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 
+ENV AWSCLI_VERSION 1.16.47
+
 RUN apt-get update && \
     apt-get install -y \
       bzip2 \
@@ -11,9 +13,16 @@ RUN apt-get update && \
       git \
       wget \
       curl \
+      python \
+      python-pip \
       bash && \
+    pip install --no-cache-dir awscli==$AWSCLI_VERSION && \
+#    apt-get --purge autoremove python-pip -y && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean 
+
+RUN echo 'source $HOME/aws/env/bin/activate' >> .bashrc && \
+    echo 'complete -C aws_completer aws' >> .bashrc
 
 ADD REPO .
 

--- a/11/jdk/slim-aws/Dockerfile
+++ b/11/jdk/slim-aws/Dockerfile
@@ -1,5 +1,5 @@
 FROM openjdk:11.0.1-jdk-slim
-MAINTAINER Forest Keepers
+MAINTAINER Forest Keepers <Jeroen.knoops@philips.com>
 
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
@@ -8,8 +8,6 @@ ENV AWSCLI_VERSION 1.16.47
 
 RUN apt-get update && \
     apt-get install -y \
-      bzip2 \
-      unzip \
       git \
       wget \
       curl \
@@ -17,12 +15,8 @@ RUN apt-get update && \
       python-pip \
       bash && \
     pip install --no-cache-dir awscli==$AWSCLI_VERSION && \
-#    apt-get --purge autoremove python-pip -y && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean 
-
-RUN echo 'source $HOME/aws/env/bin/activate' >> .bashrc && \
-    echo 'complete -C aws_completer aws' >> .bashrc
 
 ADD REPO .
 

--- a/11/jdk/slim/Dockerfile
+++ b/11/jdk/slim/Dockerfile
@@ -1,19 +1,27 @@
 FROM openjdk:11.0.1-jdk-slim
-MAINTAINER Forest Keepers
+MAINTAINER Forest Keepers <Jeroen.knoops@philips.com>
 
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
 
 RUN apt-get update && \
     apt-get install -y \
-      bzip2 \
-      unzip \
       git \
       wget \
       curl \
       bash && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean 
+
+RUN addgroup --system java && \
+    adduser --system --group java
+
+RUN mkdir /app
+RUN chown java:java /app
+
+USER java
+
+WORKDIR /app
 
 ADD REPO .
 

--- a/11/jre/slim-aws/Dockerfile
+++ b/11/jre/slim-aws/Dockerfile
@@ -1,5 +1,5 @@
 FROM openjdk:11.0.1-jre-slim
-MAINTAINER Forest Keepers
+MAINTAINER Forest Keepers <Jeroen.knoops@philips.com>
 
 RUN apt-get update && \
     apt-get install -y \
@@ -15,9 +15,6 @@ ENV AWSCLI_VERSION 1.16.47
 
 RUN pip install awscli==$AWSCLI_VERSION
 
-RUN echo 'source $HOME/aws/env/bin/activate' >> .bashrc && \
-    echo 'complete -C aws_completer aws' >> .bashrc
-
 RUN addgroup --system java && \
     adduser --system --group java
 
@@ -31,5 +28,6 @@ WORKDIR /app
 ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport"
 
 ADD REPO .
+
 # Define default command.
 CMD ["/bin/sh"]

--- a/11/jre/slim-aws/Dockerfile
+++ b/11/jre/slim-aws/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:10.0.2-13-slim
+FROM openjdk:11.0.1-jre-slim
 MAINTAINER Forest Keepers
 
 RUN apt-get update && \
@@ -7,8 +7,16 @@ RUN apt-get update && \
       jq \
       openssl \
       net-tools \
+      python-pip \
       wget && \
     rm -rf /var/lib/apt/lists/*
+
+ENV AWSCLI_VERSION 1.16.47
+
+RUN pip install awscli==$AWSCLI_VERSION
+
+RUN echo 'source $HOME/aws/env/bin/activate' >> .bashrc && \
+    echo 'complete -C aws_completer aws' >> .bashrc
 
 RUN addgroup --system java && \
     adduser --system --group java
@@ -23,6 +31,5 @@ WORKDIR /app
 ENV JAVA_TOOL_OPTIONS="-XX:+UseContainerSupport"
 
 ADD REPO .
-
 # Define default command.
 CMD ["/bin/sh"]

--- a/11/jre/slim/Dockerfile
+++ b/11/jre/slim/Dockerfile
@@ -7,16 +7,8 @@ RUN apt-get update && \
       jq \
       openssl \
       net-tools \
-      python-pip \
       wget && \
     rm -rf /var/lib/apt/lists/*
-
-ENV AWSCLI_VERSION 1.16.47
-
-RUN pip install awscli==$AWSCLI_VERSION
-
-RUN echo 'source $HOME/aws/env/bin/activate' >> .bashrc && \
-    echo 'complete -C aws_completer aws' >> .bashrc
 
 RUN addgroup --system java && \
     adduser --system --group java

--- a/11/jre/slim/Dockerfile
+++ b/11/jre/slim/Dockerfile
@@ -1,5 +1,5 @@
 FROM openjdk:11.0.1-jre-slim
-MAINTAINER Forest Keepers
+MAINTAINER Forest Keepers <Jeroen.knoops@philips.com>
 
 RUN apt-get update && \
     apt-get install -y \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,5 +13,6 @@ and this project uses the version of main tool as main version number .
 - Parallel Travis builds
 - Add REPO in dockerfile with reference to github commit
 - Push docker images to https://hub.docker.com/r/philipssoftware/openjdk/
+- Remove AWS-cli from default images. Appended all images with `-aws` for images with AWS-cli 
 
 [Unreleased]: https://github.com/philips-software/openjdk

--- a/README.md
+++ b/README.md
@@ -10,23 +10,30 @@ Current versions available:
 .
 ├── 10
 │   ├── jdk
-│   │   └── slim
+│   │   ├── slim
+│   │   │   └── Dockerfile
+│   │   └── slim-aws
 │   │       └── Dockerfile
 │   └── jre
-│       └── slim
+│       ├── slim
+│       │   └── Dockerfile
+│       └── slim-aws
 │           └── Dockerfile
 ├── 11
 │   ├── jdk
-│   │   └── slim
+│   │   ├── slim
+│   │   │   └── Dockerfile
+│   │   └── slim-aws
 │   │       └── Dockerfile
 │   └── jre
-│       └── slim
+│       ├── slim
+│       │   └── Dockerfile
+│       └── slim-aws
 │           └── Dockerfile
 ├── 8
 │   └── jre
 │       └── alpine
-│           └── Dockerfile
-```
+│           └── Dockerfile```
 ## Usage
 
 Images can be found on [https://hub.docker.com/r/philipssoftware/openjdk/](https://hub.docker.com/r/philipssoftware/openjdk/).
@@ -47,6 +54,12 @@ docker run -it --rm philipssoftware/openjdk:8 java -version
 - `openjdk:10`, `openjdk:10-jdk`, `openjdk:10-jdk-slim` [10/jdk/slim/Dockerfile](10/jdk/slim/Dockerfile)
 - `openjdk:10-jre`, `openjdk:10-jre-slim` [10/jre/slim/Dockerfile](10/jre/slim/Dockerfile)
 - `openjdk:8`, `openjdk:8-jre`, `openjdk:8-jre-alpine` [8/jre/alpine/Dockerfile](8/jre/alpine/Dockerfile)
+
+### openjdk with aws-cli
+- `openjdk:11-aws`, `openjdk:11-jdk-aws`, `openjdk:11-jdk-slim-aws` [11/jdk/slim-aws/Dockerfile](11/jdk/slim-aws/Dockerfile)
+- `openjdk:11-jre-aws`, `openjdk:11-jre-slim-aws` [11/jre/slim-aws/Dockerfile](11/jre/slim-aws/Dockerfile)
+- `openjdk:10-aws`, `openjdk:10-jdk-aws`, `openjdk:10-jdk-slim-aws` [10/jdk/slim-aws/Dockerfile](10/jdk/slim-aws/Dockerfile)
+- `openjdk:10-jre-aws`, `openjdk:10-jre-slim-aws` [10/jre/slim-aws/Dockerfile](10/jre/slim-aws/Dockerfile)
 
 ## Why
 

--- a/bin/docker_build.sh
+++ b/bin/docker_build.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+currentdir=$(pwd)
+
+cd `dirname "$0"`
+
 if [ "$#" -lt 2 ]; then
   echo "You need to provide a directory with a Dockerfile in it and a tag."
   exit 1
@@ -10,7 +14,6 @@ shift
 basetag=$1
 shift
 tags=$@
-currentdir=$(pwd)
 
 project=`basename $currentdir`
 commitsha=`git rev-parse --verify HEAD`
@@ -19,7 +22,7 @@ echo $currentdir
 
 echo "Building docker image: $builddir with tag: $basetag"
 echo "-------------------------------------------------------------------------"
-cd $builddir
+cd ../$builddir
 
 echo "https://github.com/philips-software/$project/tree/$commitsha" > REPO
 

--- a/bin/docker_build_all.sh
+++ b/bin/docker_build_all.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+cd `dirname "$0"`
+
+./docker_build.sh 11/jre/slim openjdk:11-jre openjdk:11-jre-slim
+./docker_build.sh 11/jre/slim-aws openjdk:11-jre-aws openjdk:11-jre-slim-aws
+./docker_build.sh 11/jdk/slim openjdk openjdk:11 openjdk:11-jdk openjdk:11-jdk-slim
+./docker_build.sh 11/jdk/slim-aws openjdk:11-aws openjdk:11-jdk-aws openjdk:11-jdk-slim-aws
+./docker_build.sh 10/jre/slim openjdk:10-jre openjdk:10-jre-slim
+./docker_build.sh 10/jre/slim-aws openjdk:10-jre-aws openjdk:10-jre-slim-aws
+./docker_build.sh 10/jdk/slim openjdk:10 openjdk:10-jdk openjdk:10-jdk-slim
+./docker_build.sh 10/jdk/slim-aws openjdk:10-aws openjdk:10-jdk-aws openjdk:10-jdk-slim-aws
+./docker_build.sh 8/jre/alpine openjdk:8 openjdk:8-jre openjdk:8-jre-alpine

--- a/bin/docker_build_and_push.sh
+++ b/bin/docker_build_and_push.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
+cd `dirname "$0"`
+
 if [ "$#" -lt 2 ]; then
   echo "You need to provide a directory with a Dockerfile in it and a tag."
   exit 1
 fi
 
-./bin/docker_build.sh $@
-./bin/docker_push.sh $@
+./docker_build.sh $@
+./docker_push.sh $@

--- a/bin/docker_push.sh
+++ b/bin/docker_push.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+cd `dirname "$0"`
+
 if [ "$#" -lt 2 ]; then
   echo "You need to provide a directory with a Dockerfile in it and a tag."
   exit 1
@@ -10,9 +12,6 @@ shift
 basetag=$1
 shift
 tags=$@
-currentdir=$(pwd)
-
-echo $currentdir
 
 echo "Login to docker"
 echo "-------------------------------------------------------------------------"


### PR DESCRIPTION
AWS-cli can be used in development build pipelines to push docker images to ECS.
It can also be used in production for HIPAA eligible services.

But if you don't use AWS, it's not necessary and it makes the images unnecessary big.

I've created separate versions for the images with AWS-cli. The version name appended with `-aws`

Closes #6 