### PR TITLE
Add bash to openjdk 8

### DIFF
--- a/8/jdk/alpine/Dockerfile
+++ b/8/jdk/alpine/Dockerfile
@@ -4,7 +4,10 @@ MAINTAINER Forest Keepers <Jeroen.knoops@philips.com>
 RUN apk --no-cache add \
       curl \
       jq \
+      git \
+      wget \
       openssl \
+      bash \
       net-tools && \
     rm -rf /var/cache/apk/*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project uses the version of main tool as main version number .
 ## [Unreleased]
 
 ### Changed
+- Add bash to openjdk 8 
 - Remove openjdk 10
 - Upgrade openjdk jdk to 11.0.2-jdk-slim
 - Upgrade openjdk jre to 11.0.2-jre-slim


### PR DESCRIPTION
Adds `git`, `bash` and `wget` for development purposes

closes #18 
